### PR TITLE
update to keep track of current astring extend generator convention, add usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ support for JSX syntax.
 
 see: [astring](https://www.npmjs.com/package/astring)
 
+# Usage
+
+```javascript
+ const {JsxGenerator} = require("./astringJsx"); 
+ astring.generate(ast, {generator: JsxGenerator}) 
+
+```
+
 ---
 
 ### Copyright (c) 2016 Stephen Belanger

--- a/index.js
+++ b/index.js
@@ -51,9 +51,19 @@ var generator = Object.assign({
     var output = state;
     output.write(' ');
     this[node.name.type](node.name, state);
-    output.write('=');
-    this[node.value.type](node.value, state);
+
+    if(node.value !== null) {
+      output.write('=');
+      this[node.value.type](node.value, state);
+    }
   },
+
+  JSXSpreadAttribute: function JSXSpreadAttribute(node, state) {
+    state.write('  {...')
+    this[node.argument.type](node.argument, state);
+    state.write('}');
+  },
+
   // namespaced:attr="something"
   JSXNamespacedName: function JSXNamespacedName(node, state) {
     var output = state;
@@ -67,6 +77,10 @@ var generator = Object.assign({
     output.write('{');
     this[node.expression.type](node.expression, state);
     output.write('}');
+  },
+
+  JSXEmptyExpression: function JSXEmptyExpression(node, state) {
+
   },
 
   // text

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var extend = require('xtend');
 var generator = Object.assign({
   // <div></div>
   JSXElement: function JSXElement(node, state) {
-    var output = state.output;
+    var output = state;
     output.write('<');
     this[node.openingElement.type](node.openingElement, state);
     if (node.closingElement) {
@@ -22,7 +22,7 @@ var generator = Object.assign({
   },
   // <div>
   JSXOpeningElement: function JSXOpeningElement(node, state) {
-    var output = state.output;
+    var output = state;
     this[node.name.type](node.name, state);
     for (var i = 0; i < node.attributes.length; i++) {
       var attr = node.attributes[i];
@@ -36,19 +36,19 @@ var generator = Object.assign({
   },
   // div
   JSXIdentifier: function JSXOpeningElement(node, state) {
-    var output = state.output;
+    var output = state;
     output.write(node.name);
   },
   // Member.Expression
   JSXMemberExpression: function JSXMemberExpression(node, state) {
-    var output = state.output;
+    var output = state;
     this[node.object.type](node.object, state);
     output.write('.');
     this[node.property.type](node.property, state);
   },
   // attr="something"
   JSXAttribute: function JSXAttribute(node, state) {
-    var output = state.output;
+    var output = state;
     output.write(' ');
     this[node.name.type](node.name, state);
     output.write('=');
@@ -56,19 +56,25 @@ var generator = Object.assign({
   },
   // namespaced:attr="something"
   JSXNamespacedName: function JSXNamespacedName(node, state) {
-    var output = state.output;
+    var output = state;
     this[node.namespace.type](node.namespace, state);
     output.write(':');
     this[node.name.type](node.name, state);
   },
   // {expression}
   JSXExpressionContainer: function JSXExpressionContainer(node, state) {
-    var output = state.output;
+    var output = state;
     output.write('{');
     this[node.expression.type](node.expression, state);
     output.write('}');
   },
-}, astring.defaultGenerator);
+
+  // text
+  JSXText: function JSXExpressionContainer(node, state) {
+    var output = state;
+    output.write(node.value);
+  },
+}, astring.baseGenerator);
 
 function astringJsx (ast, options) {
   return astring(ast, extend({
@@ -78,3 +84,5 @@ function astringJsx (ast, options) {
 
 astringJsx.generator = generator;
 module.exports = astringJsx;
+
+module.exports.JsxGenerator = generator; 


### PR DESCRIPTION
update to keep track of current astring extend generator convention, add usage section to README.
also added functions to handle JSXAttribute, JSXSpreadAttribute, JSXEmptyExpression. 